### PR TITLE
Change visibility to internal for all the methods of FixedMath contract

### DIFF
--- a/contracts/mocks/MockFixedMath.sol
+++ b/contracts/mocks/MockFixedMath.sol
@@ -1,0 +1,42 @@
+/*
+    The MIT License (MIT)
+
+    Copyright 2017 - 2018, Alchemy Limited, LLC.
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+pragma solidity ^0.4.19;
+
+import "../monolithic.sol";
+
+contract MockFixedMath is FixedMath {
+
+    function fMulMock(uint x, uint y) public pure returns (uint) {
+        return super.fMul(x, y);
+    }
+
+    function fDivMock(uint numerator, uint divisor) public pure returns (uint) {
+        return super.fDiv(numerator, divisor);
+    }
+
+    function fSqrtMock(uint n) public pure returns (uint) {
+        return super.fSqrt(n);
+    }
+}

--- a/contracts/monolithic.sol
+++ b/contracts/monolithic.sol
@@ -86,18 +86,18 @@ contract FixedMath {
     uint constant internal DECMULT = 10 ** DECIMALS;
 
     /// @notice Multiplication.
-    function fMul(uint x, uint y) public pure returns (uint) {
+    function fMul(uint x, uint y) internal pure returns (uint) {
         return (x.mul(y)).div(DECMULT);
     }
 
     /// @notice Devision.
-    function fDiv(uint numerator, uint divisor) public pure returns (uint) { 
+    function fDiv(uint numerator, uint divisor) internal pure returns (uint) {
         return (numerator.mul(DECMULT)).div(divisor);
     }
 
     /// @notice Square root.
     /// @dev Reference: https://stackoverflow.com/questions/3766020/binary-search-to-compute-square-root-java
-    function fSqrt(uint n) public pure returns (uint) {
+    function fSqrt(uint n) internal pure returns (uint) {
         if (n == 0) {
             return 0;
         }

--- a/test/fixedMath.js
+++ b/test/fixedMath.js
@@ -24,7 +24,7 @@
 */
 
 const assert = require('chai').assert
-const FixedMath = artifacts.require('FixedMath')
+const FixedMath = artifacts.require('MockFixedMath')
 
 contract('FixedMath', accounts => {
   let fixedMath
@@ -53,7 +53,7 @@ contract('FixedMath', accounts => {
           const a = testCase.a
           const b = testCase.b
           const expectedOutput = testCase.expected
-          const output = await fixedMath.fMul(a, b)
+          const output = await fixedMath.fMulMock(a, b)
           assert.equal(output.toNumber(), expectedOutput, 'multiply math is incorrect for case ' + i)
           resolve()
         })
@@ -82,13 +82,13 @@ contract('FixedMath', accounts => {
           if (isNaN(expectedOutput)) {
             let thrown = false
             try {
-              await fixedMath.fDiv(a, b)
+              await fixedMath.fDivMock(a, b)
             } catch (error) {
               thrown = true
             }
             assert.isTrue(thrown, 'Error is not thrown when diving by 0 for case ' + i)
           } else {
-            const output = await fixedMath.fDiv(a, b)
+            const output = await fixedMath.fDivMock(a, b)
             assert.equal(output.toNumber(), expectedOutput, 'div math is incorrect for case ' + i)
           }
 
@@ -110,7 +110,7 @@ contract('FixedMath', accounts => {
         return new Promise(async (resolve, reject) => {
           const a = testCase.a
           const expectedOutput = testCase.expected
-          const output = await fixedMath.fSqrt(a)
+          const output = await fixedMath.fSqrtMock(a)
           assert.equal(output.toNumber(), expectedOutput, 'sqrt math is incorrect for case ' + i)
           resolve()
         })


### PR DESCRIPTION
FixedMath contract is intended to be used by Formula contract only and with that in mind we can make all the methods in FixedMath contract to internal. Also Formula always calls FixedMath with 18 decimal value and this will eliminate the issue of small number being input to FixedMath. Fixed issue #14