### PR TITLE
fixed audit issue #30 . Correction in start price in case of previous auction timed out

### DIFF
--- a/contracts/monolithic.sol
+++ b/contracts/monolithic.sol
@@ -1347,11 +1347,15 @@ contract Auctions is Pricer, Owned {
             _startPrice = lastPurchasePrice / 100 + 1;
         } else {
             if (mintable == 0 || totalAuctions == 0) {
+                // Sold out scenario or someone querying projected start price of next auction
                 _startPrice = (lastPurchasePrice * 2) + 1;   
             } else {
+                // Timed out and all token not sold.
                 if (currAuc == 1) {
+                    // If initial auction timed out then price before start of new auction will touch floor price
                     _startPrice = minimumPrice * 2;
                 } else {
+                    // Descending price till end of auction and then multiply by 2
                     uint tickWhenAuctionEnded = whichTick(_startTime - 1 days);
                     uint numTick = 0;
                     if (tickWhenAuctionEnded > lastPurchaseTick) {

--- a/contracts/monolithic.sol
+++ b/contracts/monolithic.sol
@@ -1346,7 +1346,22 @@ contract Auctions is Pricer, Owned {
         if (totalAuctions > 1) {
             _startPrice = lastPurchasePrice / 100 + 1;
         } else {
-            _startPrice = (lastPurchasePrice * 2) + 1;
+            if (mintable == 0 || totalAuctions == 0) {
+                _startPrice = (lastPurchasePrice * 2) + 1;   
+            } else {
+                if (currAuc == 1) {
+                    _startPrice = minimumPrice * 2;
+                } else {
+                    uint tickWhenAuctionEnded = whichTick(_startTime - 1 days);
+                    uint numTick = 0;
+                    if (tickWhenAuctionEnded > lastPurchaseTick) {
+                        numTick = tickWhenAuctionEnded - lastPurchaseTick;
+                    }
+                    _startPrice = (priceAt(lastPurchasePrice, numTick)) * 2 + 1;
+                }
+                
+                
+            }
         }
     }
 


### PR DESCRIPTION
fixed audit issue #30 . Correction in start price in case of auction timed out.  It should be 2x of price when auction timed out instead of last purchase price.