### PR TITLE
removed one require check from cancel subscription

### DIFF
--- a/contracts/monolithic.sol
+++ b/contracts/monolithic.sol
@@ -695,7 +695,6 @@ contract METToken is Token {
     function cancelSubscription(address _recipient) public returns (bool) {
         require(subs[msg.sender][_recipient].startTime != 0);
         require(subs[msg.sender][_recipient].payPerWeek != 0);
-        require(subs[msg.sender][_recipient].lastWithdrawTime != 0);
 
         subs[msg.sender][_recipient].startTime = 0;
         subs[msg.sender][_recipient].payPerWeek = 0;


### PR DESCRIPTION
We do not need this check require(subs[msg.sender][_recipient].lastWithdrawTime != 0) because when subscription is done lastWithdrawTime is set startTime and require(subs[msg.sender][_recipient].startTime != 0); will be suffice 