### PR TITLE
Removed duplicate code from multiSubwithdraw  

### DIFF
--- a/test/mtnToken.js
+++ b/test/mtnToken.js
@@ -226,7 +226,7 @@ contract('METToken', accounts => {
         resolve()
         })
     })
-    */
+     */
 
     it('Should verify approve , approveMore and approveLess function', () => {
       return new Promise(async (resolve, reject) => {
@@ -394,7 +394,8 @@ contract('METToken', accounts => {
     it('Should verify Subscribe for future time', () => {
       return new Promise(async (resolve, reject) => {
         const payPerWeek = 1e17
-        const startTime = Math.floor((new Date(2018, 10, 8)).getTime() / 1000)
+        const date = new Date()
+        const startTime = date.setFullYear(date.getFullYear() + 1)
         await metToken.subscribe(startTime, payPerWeek, accounts[2], {from: OWNER})
         let errorMsg
         try {

--- a/timed-tests/proceeds.js
+++ b/timed-tests/proceeds.js
@@ -67,7 +67,7 @@ contract('Proceeds - timed test', accounts => {
       await TestRPCTime.mineBlock()
       let balanceOfProceed = await web3.eth.getBalance(proceeds.address)
       const tx = await proceeds.closeAuction({from: fromAccount})
-      expectedFundTranferInAC = (balanceOfProceed.mul(25)) / 10000
+      expectedFundTranferInAC = (balanceOfProceed.mul(25)).div(10000).toNumber()
       assert.equal(tx.receipt.logs.length, 2, 'Incorrect number of logs emitted')
 
       assert.equal(tx.logs.length, 1, 'Incorrect number of logs emitted')


### PR DESCRIPTION
Fixed number 10 and 14 from issue #40

1. Use address array instead of uint array
2. Changed subwithdrawFor to use if condition instead of require checks
3. Removed duplicate code from multiSubwithdrawFor
4. Updated test according to removal of require check
5. Update timed-test to use shared time travel util
