### PR TITLE
Audit Fix: Added require check in fallback in AC and Proceeds

### DIFF
--- a/contracts/monolithic.sol
+++ b/contracts/monolithic.sol
@@ -803,7 +803,7 @@ contract AutonomousConverter is Formula, Owned {
     event ConvertMetToEth(address indexed from, uint eth, uint met);
 
     function () public payable {
-        require(msg.value > 0);
+        require(msg.value > 0 && msg.sender == address(auctions.proceeds()));
         LogFundsIn(msg.sender, msg.value);
     }
 
@@ -950,7 +950,7 @@ contract Proceeds is Owned {
     uint latestAuctionClosed;
 
     function () public payable {
-        require(msg.value > 0);
+        require(msg.value > 0 && msg.sender == address(auction));
         LogProceedsIn(msg.sender, msg.value);
     }
 

--- a/test/proceeds.js
+++ b/test/proceeds.js
@@ -59,5 +59,26 @@ contract('Proceeds', accounts => {
         resolve()
       })
     })
+
+    it('Should verify that only Auctions can send fund to Proceeds', () => {
+      return new Promise(async (resolve, reject) => {
+        const amount = 1e18
+        const auctionsMock = accounts[1]
+        const proceedsBalanceBefore = await metToken.balanceOf(proceeds.address)
+        await proceeds.sendTransaction({from: auctionsMock, value: amount})
+        const proceedsBalanceAfter = await metToken.balanceOf(autonomousConverter.address)
+
+        assert(proceedsBalanceAfter.sub(proceedsBalanceBefore).valueOf(), amount, 'Auctions to Proceeds fund transfer failed')
+
+        let thrown = false
+        try {
+          await proceeds.sendTransaction({from: accounts[2], value: 1e18})
+        } catch (error) {
+          thrown = true
+        }
+        assert.isTrue(thrown, 'Proceeds should throw error')
+        resolve()
+      })
+    })
   })
 })


### PR DESCRIPTION
This fix will make sure only Auctions can send fund to Proceeds and only Proceeds can send fund to AC